### PR TITLE
Easier proxying and UI Buttons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -705,3 +705,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.idea/

--- a/WurstMod/ComponentProxy.cs
+++ b/WurstMod/ComponentProxy.cs
@@ -1,0 +1,29 @@
+﻿using UnityEngine;
+
+namespace WurstMod
+{
+    public abstract class ComponentProxy : MonoBehaviour
+    {
+        /// <summary>
+        ///     Called when the loader is resolving the proxies.
+        ///     Lets the proxy initialize the proxied component, then destroy itself
+        ///     (Note that 'itself' means the component, not the game object)
+        /// </summary>
+        public void ResolveProxy()
+        {
+            InitializeComponent();
+            Destroy(this);
+        }
+
+        /// <summary>
+        ///     This is called at run-time to resolve the proxied component.
+        /// </summary>
+        protected virtual void InitializeComponent() { }
+
+        /// <summary>
+        ///     This is called before the map is exported. Put one-time calculations and component validations here.
+        /// </summary>
+        /// TODO: Have an object represent the validation result
+        public virtual void OnExport() { }
+    }
+}

--- a/WurstMod/Entrypoint.cs
+++ b/WurstMod/Entrypoint.cs
@@ -33,6 +33,7 @@ namespace WurstMod
 
         private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode mode)
         {
+            ObjectReferences.FindReferences(scene);
             StartCoroutine(Loader.HandleTAH(scene));
             StartCoroutine(Loader.HandleGeneric(scene));
             TNH.TNH_LevelSelector.SetupLevelSelector(scene);

--- a/WurstMod/Exporter.cs
+++ b/WurstMod/Exporter.cs
@@ -34,6 +34,10 @@ namespace WurstMod
         private static void Export(LevelType type)
         {
             Scene scene = EditorSceneManager.GetActiveScene();
+            
+            // Let the proxied components know we're about to export
+            foreach (var proxy in scene.GetRootGameObjects().SelectMany(x => x.GetComponentsInChildren<ComponentProxy>())) proxy.OnExport();
+            
             List<string> warnings = new List<string>();
             string error = "";
             switch(type)

--- a/WurstMod/Generic/PointableButton.cs
+++ b/WurstMod/Generic/PointableButton.cs
@@ -1,0 +1,45 @@
+﻿using FistVR;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace WurstMod.Generic
+{
+    [RequireComponent(typeof(BoxCollider))]
+    public class PointableButton : ComponentProxy
+    {
+        // These are the colors for almost every button in the game
+        public Color ColorUnselected = new Color(0.107f, 0.286f, 0.609f, 0.628f);
+        public Color ColorSelected = new Color(0.750f, 0.793f, 0.872f, 0.847f);
+
+        [Tooltip("I think this is used for setting the color of a material? Not sure. Leave as-is.")]
+        public string ColorName = "_Color";
+
+
+        [Header("Component References")]
+        public Button Button;
+
+        public Image Image;
+        public Text Text;
+        public Renderer Rend;
+
+        protected override void InitializeComponent()
+        {
+            var proxied = gameObject.AddComponent<FVRPointableButton>();
+            proxied.ColorUnselected = ColorUnselected;
+            proxied.ColorSelected = ColorSelected;
+            proxied.Button = Button;
+            proxied.Image = Image;
+            proxied.Text = Text;
+            proxied.Rend = Rend;
+            proxied.ColorName = ColorName;
+
+            // 'Borrow' the sprite and font from the donor
+            proxied.Image.sprite = ObjectReferences.ButtonDonor.Image.sprite;
+            // TODO: This produces a NullReferenceException. Investigate.
+            //proxied.Text.font = ObjectReferences.ButtonDonor.Text.font;
+
+            // Force an update or something. Idk.
+            proxied.ForceUpdate();
+        }
+    }
+}

--- a/WurstMod/Loader.cs
+++ b/WurstMod/Loader.cs
@@ -327,6 +327,10 @@ namespace WurstMod
         /// </summary>
         private static void ResolveAll(LevelType type)
         {
+            // Resolve component proxies
+            foreach (var proxy in loadedRoot.GetComponentsInChildren<ComponentProxy>()) proxy.ResolveProxy();
+            
+            // Resolve legacy proxies
             Resolve_Skybox();
             Resolve_Shaders();
             Resolve_Terrain();

--- a/WurstMod/ObjectReferences.cs
+++ b/WurstMod/ObjectReferences.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using FistVR;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace WurstMod
+{
+    public static class ObjectReferences
+    {
+        [ObjectReference]
+        public static FVRPointableButton ButtonDonor;
+
+
+        /// <summary>
+        ///     Tries to find the appropriate object reference for the attached field.
+        ///     This should be called on scene load <b>before</b> anything messes with
+        ///     it to ensure the objects aren't destroyed.
+        /// </summary>
+        public static void FindReferences(Scene scene)
+        {
+            // A list of every GameObject in the scene
+            var gameObjects = scene.GetAllGameObjectsInScene();
+
+            // First we find every field that uses this attribute
+            foreach (var field in Assembly.GetExecutingAssembly().GetTypes().SelectMany(x => x.GetFields()))
+            {
+                // Find our attributes on that field and continue if there aren't any
+                var attributes = field.GetCustomAttributes(typeof(ObjectReferenceAttribute), true).Cast<ObjectReferenceAttribute>().ToArray();
+                if (attributes.Length == 0) continue;
+
+                // Reset the field and go over each found attribute
+                //field.SetValue(null, null);
+                foreach (var reference in attributes)
+                {
+                    // If the field's value is already set, break.
+                    if (field.GetValue(null) != null) break;
+
+                    // If the field type is GameObject, just find the GameObject normally
+                    Object found;
+                    if (field.FieldType == typeof(GameObject))
+                        found = gameObjects.FirstOrDefault(x => x.name.Contains(reference.NameFilter));
+                    // If it isn't, we also want to query for where it has a component of the right type
+                    else
+                        found = gameObjects.Where(x => x.name.Contains(reference.NameFilter)).FirstOrDefault(x => x.GetComponent(field.FieldType))?.GetComponent(field.FieldType);
+                    if (found != null) field.SetValue(null, found);
+                }
+            }
+        }
+    }
+
+    /// <summary>Attribute to represent a field that is auto-filled with an object reference when a scene is loaded.</summary>
+    /// <example>
+    ///     <code>
+    /// // Provides a reference to the scene's Camera Rig.
+    /// [ObjectReference("[CameraRig]Fixed")]
+    /// public static GameObject CameraRig;
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ObjectReferenceAttribute : Attribute
+    {
+        public ObjectReferenceAttribute(string nameFilter = "")
+        {
+            NameFilter = nameFilter;
+        }
+
+        public string NameFilter { get; }
+    }
+}

--- a/WurstMod/WurstMod.csproj
+++ b/WurstMod/WurstMod.csproj
@@ -66,11 +66,14 @@
     <Compile Include="Any\FVRReverbEnvironment.cs" />
     <Compile Include="Any\PMat.cs" />
     <Compile Include="Any\Trigger.cs" />
+    <Compile Include="ComponentProxy.cs" />
     <Compile Include="Generic\GenericPrefab.cs" />
     <Compile Include="Generic\ItemSpawner.cs" />
+    <Compile Include="Generic\PointableButton.cs" />
     <Compile Include="Generic\Spawn.cs" />
     <Compile Include="Any\Target.cs" />
     <Compile Include="Generic_LevelPopulator.cs" />
+    <Compile Include="ObjectReferences.cs" />
     <Compile Include="Patches.cs" />
     <Compile Include="TNH\AICoverPoint.cs" />
     <Compile Include="TNH\AttackVector.cs" />


### PR DESCRIPTION
**Overview:**
- ~~All `MonoBehaviour` components related to proxying in-game components now reside in `MappingComponents/`~~
- ~~Editor scripts are in the `Editor/` directory~~
- ~~Scripts that execute in-game are in the `Runtime/` directory~~
- ~~Renamed the 'Generic' level type to 'Sandbox' (Including the namespace for it's mapping components)~~
- Added a `ComponentProxy` class that makes it easier to create new component proxies.
- Added a mapping component for making functional in-game UI buttons (`PointableButton`)
- Added a class that makes getting references to in-game objects much easier (`ObjectReferences`)

**Component Proxy**:
This is a simple abstract class that enables the code to `GetComponentsInChildren()` and let the derived class resolve the proxy in it's own class. See the new button class for an example. Additionally, it has an virtual `OnExport()` method that can be used for one time calculations right before the map is exported (Some proxied components have Editor functions that can be emulated here instead of at run-time)

**ObjectReferences**:
This class will find static fields with the `ObjectReference` attribute and searches the scene for a GameObject that matches the name filter and the component type. The search is the first thing that happens when a scene is loaded to make sure nothing gets deleted before a reference can be taken. For example:
```CS
// Reference to the first GameObject in the scene that has a name containing "Destructobin"
[ObjectReference("Destructobin")]
public static GameObject DestructobinReference;

// Reference to the first SosigSpawner component found in the scene (You can also filter by name here too)
[ObjectReference]
public static SosigSpawner SosigSpawnerReference;
```
This is very useful when proxying components since we usually need to borrow values from existing game objects or components, so being able to automatically search for these references makes getting those values much easier.